### PR TITLE
Add README and license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,16 @@
+PDE Model Tools
+
+Copyright (C) 2025 letleon
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# PDE Model Tools
+
+PDE Model Tools is a Blender add-on for importing models used by PDE based games. It provides operators to load `.mesh`, `.anim` and `.skel` files directly into Blender and exposes them in a panel in the 3D Viewport sidebar.
+
+## Installation
+
+1. Build or download the add-on as a `.zip` archive.
+   - You can run `Build.bat` on Windows to create a zip using Blender's extension build command.
+2. In Blender, open **Edit > Preferences...** and switch to the **Add-ons** tab.
+3. Click **Install...**, choose the zip file and enable the *PDE Model Tools* add-on.
+
+## Basic Usage
+
+After enabling the add-on a new **PMT** panel appears in the **3D Viewport &rarr; Sidebar**. Use the buttons inside this panel to import:
+
+- `mesh_prop` files for props
+- `mesh_map` files for map geometry
+- `mesh_wcm` files for weapons/characters
+- `.anim` animation files
+- `.skel` skeleton files
+
+Select a file when prompted and it will be loaded into the current scene.


### PR DESCRIPTION
## Summary
- document addon purpose and usage in README
- add project license

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c6bd0524c83279e183275668107d9