### PR TITLE
Fix invalid group name logs

### DIFF
--- a/anim/operator.py
+++ b/anim/operator.py
@@ -277,17 +277,17 @@ class ImportAnimClass(bpy.types.Operator):
     def is_valid_group_name(self, now_group_name):
         # 检查是否为空
         if not now_group_name:
-            log.debug("!名称为空。%s", format(now_group_name))
+            log.debug("!名称为空。%s", now_group_name)
             return False
 
         # 检查是否为字符串
         if not isinstance(now_group_name, str):
-            log.debug("!不是字符串 %s", format(now_group_name))
+            log.debug("!不是字符串 %s", now_group_name)
             return False
 
         # 使用正则表达式匹配只包含a-z, A-Z, 且不以数字开头，包含0-9, _的字符串
         if re.match("^[a-zA-Z_][a-zA-Z0-9_]*$", now_group_name):
             return True
         else:
-            log.debug("包含非法字符或以数字开头! %s".format(now_group_name))
+            log.debug("包含非法字符或以数字开头! %s", now_group_name)
             return False


### PR DESCRIPTION
## Summary
- remove `format` call from `is_valid_group_name` logger

## Testing
- `python -m py_compile anim/operator.py`


------
https://chatgpt.com/codex/tasks/task_e_685c6bb5b4b883278e2d17594c724f97